### PR TITLE
For the `anchor-has-content` rule, allow anchors with explicit aria labels to pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [Unreleased]
 
+### Changed
+
+- For the `anchor-has-content` rule, allow anchors with explicit aria labels to pass.
+
 ## [0.2.0] - 2020-06-26
 
 ### Changed

--- a/src/rules/__tests__/anchor-has-content.test.js
+++ b/src/rules/__tests__/anchor-has-content.test.js
@@ -8,7 +8,8 @@ makeRuleTester("anchor-has-content", rule, {
     "<a v-text='msg' />",
     "<a v-html='msg' />",
     "<a><slot /></a>",
-    "<Anchor  />"
+    "<Anchor  />",
+    "<a aria-label='This is my label' />"
   ],
   invalid: [
     "<a />",

--- a/src/rules/anchor-has-content.js
+++ b/src/rules/anchor-has-content.js
@@ -1,6 +1,7 @@
 const {
   defineTemplateBodyVisitor,
   getElementType,
+  hasAriaLabel,
   hasContent,
   makeDocsURL
 } = require("../utils");
@@ -34,7 +35,11 @@ module.exports = {
         const elementTypes = ["a"].concat(components);
         const elementType = getElementType(node);
 
-        if (elementTypes.includes(elementType) && !hasContent(node)) {
+        if (
+          elementTypes.includes(elementType) &&
+          !hasContent(node) &&
+          !hasAriaLabel(node)
+        ) {
           context.report({ node, messageId: "default" });
         }
       }


### PR DESCRIPTION
Closes #15
