### PR TITLE
Add meta fields to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,19 @@
   },
   "author": "Kevin Deisz",
   "license": "MIT",
+  "repository": "github:vue-a11y/eslint-plugin-vuejs-accessibility",
+  "bugs": {
+    "url": "https://github.com/vue-a11y/eslint-plugin-vuejs-accessibility/issues"
+  },
+  "homepage": "https://github.com/vue-a11y/eslint-plugin-vuejs-accessibility#readme",
+  "keywords": [
+    "eslint",
+    "eslint-plugin",
+    "a11y",
+    "accessibility",
+    "vue",
+    "vuejs"
+  ],
   "peerDependencies": {
     "eslint": "^5.0.0 || ^6.0.0 || ^7.0.0"
   },
@@ -55,5 +68,8 @@
   },
   "prettier": {
     "trailingComma": "none"
+  },
+  "directories": {
+    "doc": "docs"
   }
 }


### PR DESCRIPTION
I noticed by chance that `package.json` is missing some meta fields (related to the repository URL, folders, and keywords), so here is a PR to fix this.

In my case, Renovate bot PRs was not adding the project homepage URL to its updates table summary.