### PR TITLE
Fix crash when using rules with file other than .vue

### DIFF
--- a/src/utils/__tests__/defineTemplateBodyVisitor.test.ts
+++ b/src/utils/__tests__/defineTemplateBodyVisitor.test.ts
@@ -1,0 +1,32 @@
+import assert from "assert";
+import { Linter } from "eslint";
+import plugin from "../../index";
+
+describe("Don't crash even if without vue-eslint-parser.", () => {
+  const code = "var a;";
+
+  for (const [key, rule] of Object.entries(plugin.rules)) {
+    const ruleId = `vuejs-accessibility/${key}`;
+
+    it(ruleId, () => {
+      const linter = new Linter();
+      linter.defineRule(ruleId, rule);
+      const config: Linter.Config = {
+        parser: "espree",
+        rules: {
+          [ruleId]: "error"
+        }
+      };
+      const resultVue = linter.verifyAndFix(code, config, "test.vue");
+      for (const { message } of resultVue.messages) {
+        assert.strictEqual(
+          message,
+          "Use the latest vue-eslint-parser. See also https://eslint.vuejs.org/user-guide/#what-is-the-use-the-latest-vue-eslint-parser-error."
+        );
+      }
+
+      const resultJs = linter.verifyAndFix(code, config, "test.js");
+      assert.strictEqual(resultJs.messages.length, 0);
+    });
+  }
+});

--- a/src/utils/defineTemplateBodyVisitor.ts
+++ b/src/utils/defineTemplateBodyVisitor.ts
@@ -1,3 +1,4 @@
+import path from "path";
 import type { Rule } from "eslint";
 import type { AST } from "vue-eslint-parser";
 
@@ -13,12 +14,15 @@ function defineTemplateBodyVisitor(
   templateVisitor: TemplateListener,
   scriptVisitor?: Rule.RuleListener
 ) {
-  if (context.parserServices.defineTemplateBodyVisitor === null) {
-    context.report({
-      loc: { line: 1, column: 0 },
-      message:
-        "Use the latest vue-eslint-parser. See also https://eslint.vuejs.org/user-guide/#what-is-the-use-the-latest-vue-eslint-parser-error"
-    });
+  if (context.parserServices.defineTemplateBodyVisitor == null) {
+    const filename = context.getFilename();
+    if (path.extname(filename) === ".vue") {
+      context.report({
+        loc: { line: 1, column: 0 },
+        message:
+          "Use the latest vue-eslint-parser. See also https://eslint.vuejs.org/user-guide/#what-is-the-use-the-latest-vue-eslint-parser-error."
+      });
+    }
 
     return {};
   }


### PR DESCRIPTION
This PR fixes an issue that would crash if we used the rules in file other than `.vue`.

The cause of the crash was that the if statement was wrong.

Before: `if (context.parserServices.defineTemplateBodyVisitor === null) {`
After: `if (context.parserServices.defineTemplateBodyVisitor == null) {`

The condition is not used because `context.parserServices.defineTemplateBodyVisitor` is `undefined`.
This issue was found in https://github.com/ota-meshi/eslint-plugin-json-schema-validator/issues/76#issuecomment-875217531.

Also, didn't use warnings originally, but I've changed it to report warnings about parsers only for `.vue` files.

