### PR TITLE
Fix error message typo in interactive-supports-focus rule

### DIFF
--- a/src/rules/interactive-supports-focus.ts
+++ b/src/rules/interactive-supports-focus.ts
@@ -107,7 +107,7 @@ const rule: InteractiveSupportsFocus = {
     },
     messages: {
       tabbable: `Elements with the "{{role}}" interactive role must be tabbable.`,
-      focusable: `Elements with the "{{role}" interactive role must be focusable.`
+      focusable: `Elements with the "{{role}}" interactive role must be focusable.`
     },
     schema: [
       {


### PR DESCRIPTION
Hello!

Great project! While fixing some linting errors I encountered a typo that was preventing the correct formatting of the error message for the `interactive-supports-focus` rule.