### PR TITLE
chore: add ESLint 8 to supported `peerDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "vuejs"
   ],
   "peerDependencies": {
-    "eslint": "^5.0.0 || ^6.0.0 || ^7.0.0"
+    "eslint": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
   },
   "dependencies": {
     "aria-query": "^5.0.0",


### PR DESCRIPTION
Closes #295 

All tests are passing, so this appears to be working fine. Thanks for the great plugin!