### PR TITLE
Add labelComponents option to form control has label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [Unreleased]
 
+### Added
+
+- `labelComponents` options to add custom label components in `form-control-has-label`
+
 ### Changed
 
 - Deprecate the accessible-emoji rule. See https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/issues/627 for details.

--- a/docs/form-control-has-label.md
+++ b/docs/form-control-has-label.md
@@ -8,6 +8,23 @@ _References:_
 
 ## Rule details
 
+This rule takes one optional object argument of type object:
+
+```json
+{
+  "rules": {
+    "vuejs-accessibility/form-control-has-label": [
+      "error",
+      {
+        "labelComponents": ["CustomLabel"],
+      }
+    ]
+  }
+}
+```
+
+For the `labelComponents` option, these strings determine which elements (**always including** `<label>`) should be checked for having the `for` prop. This is a good use case when you have a wrapper component that simply renders a `label` element.
+
 ### Succeed
 
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-vuejs-accessibility",
-  "version": "1.2.0",
+  "version": "1.1.0",
   "description": "An eslint plugin for checking Vue.js files for accessibility",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-vuejs-accessibility",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "An eslint plugin for checking Vue.js files for accessibility",
   "main": "dist/index.js",
   "scripts": {

--- a/src/rules/__tests__/form-control-has-label.test.ts
+++ b/src/rules/__tests__/form-control-has-label.test.ts
@@ -21,7 +21,15 @@ makeRuleTester("form-control-has-label", rule, {
       <div aria-hidden="true">
         <input value="1" type="text" />
       </div>
-    `
+    `,
+    {
+      code: "<custom-label for='input'>text</custom-label><input type='text' id='input' />",
+      options: [{ labelComponents: ["CustomLabel"] }]
+    },
   ],
-  invalid: ["<input type='text' />", "<textarea type='text'></textarea>"]
+  invalid: [
+    "<input type='text' />", 
+    "<textarea type='text'></textarea>",
+    "<custom-label for='input'>text</custom-label><input type='text' id='input' />"
+  ]
 });

--- a/src/rules/form-control-has-label.ts
+++ b/src/rules/form-control-has-label.ts
@@ -44,7 +44,21 @@ const rule: Rule.RuleModule = {
     messages: {
       default:
         "Each form element must have a programmatically associated label element."
-    }
+    },
+    schema: [
+      {
+        type: "object",
+        properties: {
+          labelComponents: {
+            type: "array",
+            items: {
+              type: "string"
+            },
+            uniqueItems: true
+          }
+        }
+      }
+    ]
   },
   create(context) {
     return defineTemplateBodyVisitor(context, {

--- a/src/rules/form-control-has-label.ts
+++ b/src/rules/form-control-has-label.ts
@@ -21,10 +21,10 @@ function isLabelElement(
     | AST.VDocumentFragment
     | AST.VText
     | AST.VExpressionContainer,
-  options: FormControlHasLabelOptions
+  { labelComponents = [] }: FormControlHasLabelOptions
 ) {
-  const labelComponents = (options.labelComponents || []).map(makeKebabCase).concat("label");
-  return node.type === "VElement" && labelComponents.includes(getElementType(node));
+  const allLabelComponents = labelComponents.map(makeKebabCase).concat("label");
+  return node.type === "VElement" && allLabelComponents.includes(getElementType(node));
 }
 
 function hasLabelElement(node: AST.VElement, options: FormControlHasLabelOptions): boolean {

--- a/src/rules/form-control-has-label.ts
+++ b/src/rules/form-control-has-label.ts
@@ -11,8 +11,8 @@ import {
   getElementType,
   hasAriaLabel,
   isAriaHidden,
+  isMatchingElement,
   makeDocsURL,
-  makeKebabCase,
 } from "../utils";
 
 function isLabelElement(
@@ -23,8 +23,8 @@ function isLabelElement(
     | AST.VExpressionContainer,
   { labelComponents = [] }: FormControlHasLabelOptions
 ) {
-  const allLabelComponents = labelComponents.map(makeKebabCase).concat("label");
-  return node.type === "VElement" && allLabelComponents.includes(getElementType(node));
+  const allLabelComponents = labelComponents.concat("label");
+  return isMatchingElement(node, allLabelComponents);
 }
 
 function hasLabelElement(node: AST.VElement, options: FormControlHasLabelOptions): boolean {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,6 +14,7 @@ export { default as isAriaHidden } from "./utils/isAriaHidden";
 export { default as isAttribute } from "./utils/isAttribute";
 export { default as isHiddenFromScreenReader } from "./utils/isHiddenFromScreenReader";
 export { default as isInteractiveElement } from "./utils/isInteractiveElement";
+export { default as isMatchingElement } from "./utils/isMatchingElement";
 export { default as isPresentationRole } from "./utils/isPresentationRole";
 export { default as makeDocsURL } from "./utils/makeDocsURL";
 export { default as makeKebabCase } from "./utils/makeKebabCase";

--- a/src/utils/isMatchingElement.ts
+++ b/src/utils/isMatchingElement.ts
@@ -1,0 +1,23 @@
+import type { AST } from "vue-eslint-parser";
+
+import getElementType from "./getElementType";
+import makeKebabCase from "./makeKebabCase";
+
+function isMatchingElement(
+  node:
+  | AST.VElement
+  | AST.VDocumentFragment
+  | AST.VText
+  | AST.VExpressionContainer, 
+  searchArray: string[]
+) {
+  if (!(node.type === "VElement")) return false;
+
+  const elementType = getElementType(node);
+  
+  return searchArray.some((item: string) => {
+    return makeKebabCase(item) === elementType;
+  });
+}
+
+export default isMatchingElement;


### PR DESCRIPTION
We have custom label components in our app which means the `form-control-has-label` rule is always triggered. 

I've leant on the options setup for `label-has-for` and implemented a similar setup where you can pass an array of custom components to be considered as `label` elements by the rule for validation.

In the app template:

```
<CustomLabel for="myInput">Label</CustomLabel>
<input type="text" id="myInput" />
```

Pass the label components as part of the ruleset:

```
"vuejs-accessibility/form-control-has-label": [
      "error",
      {
        "labelComponents": ["CustomLabel"],
      }
    ]
```