### PR TITLE
Added the ability to specify label components that require a label attribute

### DIFF
--- a/docs/form-control-has-label.md
+++ b/docs/form-control-has-label.md
@@ -16,6 +16,7 @@ This rule takes one optional object argument of type object:
     "vuejs-accessibility/form-control-has-label": [
       "error",
       {
+        "labelComponentsWithLabel": ["CustomComponentWithLabelAttribute"],
         "labelComponents": ["CustomLabel"],
         "controlComponents": ["CustomInput"]
       }
@@ -25,6 +26,8 @@ This rule takes one optional object argument of type object:
 ```
 
 For the `labelComponents` option, these strings determine which elements (**always including** `<label>`) should be checked for having the `for` prop. This is a good use case when you have a wrapper component that simply renders a `label` element.
+
+For the `labelComponentsWithLabel` option, these strings determine which elements should be checked for having a `label` or `aria-label` prop. This is a good use case when you have a wrapper component that renders a `label` element when provided.
 
 For the `controlComponents` option, these strings determine which elements (**always including** `<input>`, `<textarea>` and `<select>`) should be checked for having an associated label. This is a good use case when you have a wrapper component that simply renders an input element.
 

--- a/src/rules/__tests__/form-control-has-label.test.ts
+++ b/src/rules/__tests__/form-control-has-label.test.ts
@@ -26,6 +26,10 @@ makeRuleTester("form-control-has-label", rule, {
       code: "<custom-label for='input'>text</custom-label><input type='text' id='input' />",
       options: [{ labelComponents: ["CustomLabel"] }]
     },
+    {
+      code: "<custom-label label='input'>text</custom-label><input type='text' id='input' />",
+      options: [{ labelComponentsWithLabel: ["CustomLabel"] }]
+    },
     "<b-form-input />"
   ],
   invalid: [
@@ -36,6 +40,16 @@ makeRuleTester("form-control-has-label", rule, {
       code: "<div><b-form-input /></div>",
       options: [{ controlComponents: ["b-form-input"] }],
       errors: [{ messageId: "default" }]
-    }
+    },
+    {
+      code: "<div aria-label='text'><b-form-input /></div>",
+      options: [{ controlComponents: ["b-form-input"] }],
+      errors: [{ messageId: "default" }]
+    },
+    {
+      code: "<custom-label>text</custom-label><input type='text' id='input' />",
+      options: [{ labelComponentsWithLabel: ["CustomLabel"] }],
+      errors: [{ messageId: "default" }]
+    },
   ]
 });

--- a/src/rules/__tests__/form-control-has-label.test.ts
+++ b/src/rules/__tests__/form-control-has-label.test.ts
@@ -27,7 +27,7 @@ makeRuleTester("form-control-has-label", rule, {
       options: [{ labelComponents: ["CustomLabel"] }]
     },
     {
-      code: "<custom-label label='input'>text</custom-label><input type='text' id='input' />",
+      code: "<custom-label label='text'><input type='text' id='input' /></custom-label>",
       options: [{ labelComponentsWithLabel: ["CustomLabel"] }]
     },
     "<b-form-input />"
@@ -42,12 +42,17 @@ makeRuleTester("form-control-has-label", rule, {
       errors: [{ messageId: "default" }]
     },
     {
-      code: "<div aria-label='text'><b-form-input /></div>",
+      code: "<div label='text'><b-form-input /></div>",
       options: [{ controlComponents: ["b-form-input"] }],
       errors: [{ messageId: "default" }]
     },
     {
-      code: "<custom-label>text</custom-label><input type='text' id='input' />",
+      code: "<custom-label><input type='text' id='input' /></custom-label>",
+      options: [{ labelComponentsWithLabel: ["CustomLabel"] }],
+      errors: [{ messageId: "default" }]
+    },
+    {
+      code: "<custom-label label='text'>label next to input</custom-label><input type='text' id='input' />",
       options: [{ labelComponentsWithLabel: ["CustomLabel"] }],
       errors: [{ messageId: "default" }]
     },

--- a/src/rules/form-control-has-label.ts
+++ b/src/rules/form-control-has-label.ts
@@ -22,16 +22,19 @@ function isLabelElement(
     | AST.VDocumentFragment
     | AST.VText
     | AST.VExpressionContainer,
-  { labelComponents = [], labelComponentsWithLabel = [] }: FormControlHasLabelOptions
+  { labelComponents = [] }: FormControlHasLabelOptions
 ) {
-  if (!(node.type === "VElement")) return false;
   const allLabelComponents = labelComponents.concat("label");
-  return (
-    isMatchingElement(node, allLabelComponents)
-    || (
-      isMatchingElement(node, labelComponentsWithLabel)
-      && (hasAriaLabel(node) || getElementAttributeValue(node, "label"))
-    )
+  return isMatchingElement(node, allLabelComponents);
+}
+
+function isElementWithLabel(
+  node: | AST.VElement,
+  { labelComponentsWithLabel = [] }: FormControlHasLabelOptions
+) {
+  return Boolean(
+    isMatchingElement(node, labelComponentsWithLabel)
+    && (hasAriaLabel(node) || getElementAttributeValue(node, "label"))
   );
 }
 
@@ -45,7 +48,7 @@ function hasLabelElement(
     [parent, ...parent.children].some((node) =>
       isLabelElement(node, options)
     ) ||
-    (parent && parent.type === "VElement" && hasLabelElement(parent, options))
+    (parent && parent.type === "VElement" && (isElementWithLabel(parent, options) || hasLabelElement(parent, options)))
   );
 }
 

--- a/src/rules/form-control-has-label.ts
+++ b/src/rules/form-control-has-label.ts
@@ -3,6 +3,7 @@ import type { AST } from "vue-eslint-parser";
 
 interface FormControlHasLabelOptions {
   labelComponents: string[];
+  labelComponentsWithLabel: string[];
 }
 
 import {
@@ -21,10 +22,17 @@ function isLabelElement(
     | AST.VDocumentFragment
     | AST.VText
     | AST.VExpressionContainer,
-  { labelComponents = [] }: FormControlHasLabelOptions
+  { labelComponents = [], labelComponentsWithLabel = [] }: FormControlHasLabelOptions
 ) {
+  if (!(node.type === "VElement")) return false;
   const allLabelComponents = labelComponents.concat("label");
-  return isMatchingElement(node, allLabelComponents);
+  return (
+    isMatchingElement(node, allLabelComponents)
+    || (
+      isMatchingElement(node, labelComponentsWithLabel)
+      && (hasAriaLabel(node) || getElementAttributeValue(node, "label"))
+    )
+  );
 }
 
 function hasLabelElement(


### PR DESCRIPTION
Vue bootstrap makes use of a parent component that requires a `label` attribute before it actually has a label. This PR allows to specifically check for this use case:
https://bootstrap-vue.org/docs/components/form-group#label
```html
    <b-form-group
      label="Enter your name"
      label-for="input-horizontal"
    >
      <b-form-input id="input-horizontal"></b-form-input>
    </b-form-group>
```