### PR TITLE
docs: fix "Edit this page" links, and links on the rules overview page

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,11 +1,12 @@
 import { defineConfig } from "vitepress";
 import { rules } from "./rulesForSidebar";
 import { description, version } from "../../package.json";
+import { BASE_URL } from "./constants";
 
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
   title: "eslint-plugin-vuejs-a11y",
-  base: "/eslint-plugin-vuejs-accessibility/",
+  base: BASE_URL,
   description,
   head: [
     [
@@ -66,7 +67,7 @@ export default defineConfig({
 
     editLink: {
       pattern:
-        "https://github.com/vue-a11y/eslint-plugin-vuejs-accessibility/edit/master/docs/:path"
+        "https://github.com/vue-a11y/eslint-plugin-vuejs-accessibility/edit/main/docs/:path"
     },
 
     socialLinks: [

--- a/docs/.vitepress/constants.ts
+++ b/docs/.vitepress/constants.ts
@@ -1,0 +1,1 @@
+export const BASE_URL = "/eslint-plugin-vuejs-accessibility/";

--- a/docs/.vitepress/rulesForSidebar.ts
+++ b/docs/.vitepress/rulesForSidebar.ts
@@ -1,5 +1,6 @@
 import { join, parse } from "node:path";
 import { Dirent, readdirSync } from "node:fs";
+import { BASE_URL } from "./constants";
 
 export const rules = getRulesForSideBar();
 
@@ -29,6 +30,6 @@ function fileNameWithoutExtension(file: Dirent) {
 function ruleToSidebarItem(ruleName: string) {
   return {
     text: ruleName,
-    link: `/rules/${ruleName}`
+    link: `${BASE_URL}rules/${ruleName}`
   };
 }


### PR DESCRIPTION
This PR aims to fix 2 issues I made when creating the docs page:

- links are missing the base url in the [rule summary](https://vue-a11y.github.io/eslint-plugin-vuejs-accessibility/rule-overview/) and navigating to the 404 page
- the "Edit this page" links give 404 as well, because the main branch is called `main` in this repository instead of `master`

My apologies