### PR TITLE
fix: ignore docs during build

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,5 @@
 .*
 bin/
+docs/
 src/
 jest.setup.ts

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["bin", "src/**/__tests__", "jest.setup.ts"]
+  "exclude": ["bin", "src/**/__tests__", "docs/**", "jest.setup.ts"]
 }


### PR DESCRIPTION
The default `tsconfig.json` compiles every `ts` file it finds, so the `docs` folder was compiled into the `dist` folder 🙈