### PR TITLE
chore(site): fix broken rule menu links

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,12 +1,11 @@
 import { defineConfig } from "vitepress";
 import { rules } from "./rulesForSidebar";
 import { description, version } from "../../package.json";
-import { BASE_URL } from "./constants";
 
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
   title: "eslint-plugin-vuejs-a11y",
-  base: BASE_URL,
+  base: "/eslint-plugin-vuejs-accessibility/",
   description,
   head: [
     [

--- a/docs/.vitepress/constants.ts
+++ b/docs/.vitepress/constants.ts
@@ -1,1 +1,0 @@
-export const BASE_URL = "/eslint-plugin-vuejs-accessibility/";

--- a/docs/.vitepress/rulesForSidebar.ts
+++ b/docs/.vitepress/rulesForSidebar.ts
@@ -1,6 +1,5 @@
 import { join, parse } from "node:path";
 import { Dirent, readdirSync } from "node:fs";
-import { BASE_URL } from "./constants";
 
 export const rules = getRulesForSideBar();
 
@@ -30,6 +29,6 @@ function fileNameWithoutExtension(file: Dirent) {
 function ruleToSidebarItem(ruleName: string) {
   return {
     text: ruleName,
-    link: `${BASE_URL}rules/${ruleName}`
+    link: `/rules/${ruleName}`
   };
 }


### PR DESCRIPTION
Clicking on the rules menu on the new site shows a 404 page.
This PR fixes that broken link.