### PR TITLE
fix: use relative path for table links

### DIFF
--- a/docs/rule-overview/rule-overview.data.mts
+++ b/docs/rule-overview/rule-overview.data.mts
@@ -16,7 +16,7 @@ export default defineLoader({
     const recommended = getRecommendedRules();
     return rules.map((rule) => ({
       name: rule.text,
-      link: rule.link,
+      link: formatRuleLink(rule.link),
       recommended: recommended.includes(rule.text)
     }));
   }
@@ -31,4 +31,8 @@ function getRecommendedRules() {
 
 function removeRulePrefix(ruleName: string) {
   return ruleName.replace("vuejs-accessibility/", "");
+}
+
+function formatRuleLink(ruleLink: string) {
+  return "..".concat(ruleLink);
 }


### PR DESCRIPTION
## Description of the issue

On the page [Rule Overview](https://vue-a11y.github.io/eslint-plugin-vuejs-accessibility/rule-overview/):
- Left clicking on the links in the table navigates to the Getting started page
- Middle clicking on the links in the table navigates to `https://vue-a11y.github.io/rules/{ruleName}` (e.g. https://vue-a11y.github.io/rules/alt-text)

## Suggested fix

It seems like the `base` URL (`/eslint-plugin-vuejs-accessibility/`) is ignored. I think this is because the table is in a `.vue` file and we're using a `<a>` tag directly.

So I suggest switching to a relative path to link to the rule: `../rules/{rule-name}`