### PR TITLE
fix: use types from eslint for flat config

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "semver": "^7.6.0",
     "ts-jest": "^29.0.3",
     "ts-node": "^10.3.0",
-    "typescript": "^5.0.2",
+    "typescript": "5.0.2",
     "vitepress": "1.2.3"
   },
   "eslintConfig": {

--- a/src/configs/flat/recommended.ts
+++ b/src/configs/flat/recommended.ts
@@ -1,3 +1,4 @@
+import type { Linter } from "eslint";
 import globals from "globals";
 import { rules } from "../rules";
 
@@ -29,6 +30,6 @@ const recommended = [
     },
     rules
   }
-];
+] satisfies Linter.FlatConfig[];
 
 export = recommended;

--- a/src/configs/recommended.ts
+++ b/src/configs/recommended.ts
@@ -1,7 +1,7 @@
 import type { Linter } from "eslint";
 import { rules } from "./rules";
 
-const recommended: Linter.BaseConfig = {
+const recommended = {
   parser: require.resolve("vue-eslint-parser"),
   parserOptions: {
     ecmaVersion: 2020,
@@ -13,6 +13,6 @@ const recommended: Linter.BaseConfig = {
   },
   plugins: ["vuejs-accessibility"],
   rules
-};
+} satisfies Linter.BaseConfig;
 
 export default recommended;

--- a/src/utils/defineTemplateBodyVisitor.ts
+++ b/src/utils/defineTemplateBodyVisitor.ts
@@ -38,7 +38,6 @@ function defineTemplateBodyVisitor(
  * @see https://eslint.org/blog/2023/09/preparing-custom-rules-eslint-v9/#from-context-to-sourcecode
  */
 function getParserServices(context: Rule.RuleContext) {
-  // @ts-expect-error TODO: remove this when eslint v8 support is dropped
   const legacy = context.sourceCode;
 
   return legacy ? legacy.parserServices : context.parserServices;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1220,9 +1220,9 @@
     "@types/estree" "*"
 
 "@types/eslint@*":
-  version "8.4.10"
-  resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-8.4.10.tgz#19731b9685c19ed1552da7052b6f668ed7eb64bb"
-  integrity sha512-Sl/HOqN8NKPmhWo2VBEPm0nvHnu2LL3v9vKo8MEq0EtbJ4eVzGPl41VNPvn5E1i5poMk4/XD8UriLHpJvEP/Nw==
+  version "8.56.10"
+  resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-8.56.10.tgz#eb2370a73bf04a901eeba8f22595c7ee0f7eb58d"
+  integrity sha512-Shavhk87gCtY2fhXDctcfS3e6FdxWkCx1iUZ9eEUbh7rTqlZT0/IzOkCOVt0fCjcFuZ9FPYfuezTBImfHCDBGQ==
   dependencies:
     "@types/estree" "*"
     "@types/json-schema" "*"
@@ -5330,10 +5330,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^5.0.2:
-  version "5.5.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.5.2.tgz#c26f023cb0054e657ce04f72583ea2d85f8d0507"
-  integrity sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==
+typescript@5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.2.tgz#891e1a90c5189d8506af64b9ef929fca99ba1ee5"
+  integrity sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==
 
 undici-types@~5.26.4:
   version "5.26.5"


### PR DESCRIPTION
To avoid TS errors when using this plugin with flat config

![image](https://github.com/vue-a11y/eslint-plugin-vuejs-accessibility/assets/12446546/c229f421-1504-4af6-a4f4-4bc030a0baa6)
