### PR TITLE
Add output as controlType for label-has-for rule

### DIFF
--- a/src/rules/label-has-for.ts
+++ b/src/rules/label-has-for.ts
@@ -18,7 +18,14 @@ type Required =
 
 type Options = { allowChildren: boolean; controlComponents: string[] };
 
-const controlTypes = ["input", "meter", "progress", "select", "textarea"];
+const controlTypes = [
+  "input",
+  "textarea",
+  "select",
+  "meter",
+  "output",
+  "progress"
+];
 
 function validateNesting(node: AST.VElement, options: Options): boolean {
   return node.children.some((child) => {


### PR DESCRIPTION
Output element is already in list of controlComponents for form-control-has-label rule. Sort list of controlTypes to be same as in form-control-has-label rule.

This is necessary because `form-control-has-label` complains that `output` should have a label:
```js
<output />
```
`error  Each form element must have a programmatically associated label element  vuejs-accessibility/form-control-has-label`

But if you do it complains about the label not being associated with a control:
```js
<label for="out">
  <output id="out" />
</label>
```
`error  Form label must have an associated control  vuejs-accessibility/label-has-for`

Changing the `output` to `progress` removes the error, because it is already supported:
```js
<label for="out">
  <progress id="out" />
</label>
```