### PR TITLE
Type Tweak for the `Files` Property

### DIFF
--- a/src/configs/flat/recommended.ts
+++ b/src/configs/flat/recommended.ts
@@ -30,6 +30,6 @@ const recommended = [
     },
     rules
   }
-] satisfies Linter.FlatConfig[];
+] as const satisfies Linter.FlatConfig[];
 
 export = recommended;


### PR DESCRIPTION
When using the flat config in a typechecked ESLint file (with `exactOptionalPropertyTypes: true`), a type error is reported because the generated type for `flat/recommended` is a union, where one element in the union contains `files?: undefined`. As per ESLint's `Config` type, `files` can be omitted, but it cannot be explicitly `undefined`.

This uses a const assertion so that, in the inferred type, `files` is correctly omitted (or an array of strings).

(https://www.totaltypescript.com/concepts/as-const)



