### PR TITLE
docs(no-autofocus): update resource link from W3C to WHATWG

### DIFF
--- a/docs/rules/no-autofocus.md
+++ b/docs/rules/no-autofocus.md
@@ -38,4 +38,4 @@ For the `ignoreNonDOM` option, this determines if developer created components a
 
 ## 📚 Resources
 
-- [W3C](https://w3c.github.io/html/sec-forms.html#autofocusing-a-form-control-the-autofocus-attribute)
+- [WHATWG](https://html.spec.whatwg.org/multipage/forms.html#autofocusing-a-form-control-the-autofocus-attribute)


### PR DESCRIPTION
## Description

The resource link in the `no-autofocus` rule documentation was pointing to the W3C specification, but the autofocus attribute specification is now maintained by WHATWG.

## Changes

- Updated the resource link from W3C to WHATWG HTML specification