### PR TITLE
fix: check `accessibleDirectives` on child elements

### DIFF
--- a/src/rules/__tests__/anchor-has-content.test.ts
+++ b/src/rules/__tests__/anchor-has-content.test.ts
@@ -18,6 +18,10 @@ makeRuleTester("anchor-has-content", rule, {
       options: [{ accessibleDirectives: ["accessibleDirective"] }]
     },
     {
+      code: "<a><span v-accessibleDirective='msg' /></a>",
+      options: [{ accessibleDirectives: ["accessibleDirective"] }]
+    },
+    {
       code: "<a><accessible-child /></a>",
       options: [{ accessibleChildren: ["AccessibleChild"] }]
     }

--- a/src/rules/__tests__/heading-has-content.test.ts
+++ b/src/rules/__tests__/heading-has-content.test.ts
@@ -14,6 +14,10 @@ makeRuleTester("heading-has-content", rule, {
       options: [{ accessibleDirectives: ["accessibleDirective"] }]
     },
     {
+      code: "<h1><span v-accessibleDirective='msg'></span></h1>",
+      options: [{ accessibleDirectives: ["accessibleDirective"] }]
+    },
+    {
       code: "<h1><accessible-child /></h1>",
       options: [{ accessibleChildren: ["AccessibleChild"] }]
     }

--- a/src/utils/hasContent.ts
+++ b/src/utils/hasContent.ts
@@ -40,7 +40,9 @@ function hasAccessibleDirective(
   accessibleDirectives: string[]
 ): boolean {
   return accessibleDirectives.some((directive) => {
-    return hasDirective(node, directive);
+    return (
+      hasDirective(node, directive) || hasChildWithDirective(node, directive)
+    );
   });
 }
 


### PR DESCRIPTION
### Problem

`hasContent()` checks the hardcoded `v-text` / `v-html` directives on both the element and its children:

```ts
hasDirective(node, "text") ||
hasDirective(node, "html") ||
hasChildWithDirective(node, "text") ||
hasChildWithDirective(node, "html") ||
```

but the configurable `accessibleDirectives` only on the element itself:

```ts
function hasAccessibleDirective(node, accessibleDirectives) {
  return accessibleDirectives.some((directive) => {
    return hasDirective(node, directive);
  });
}
```

So `<h1><span v-my-directive="msg" /></h1>` is reported as an empty heading, even with `accessibleDirectives: ["my-directive"]` set.

The only way to silence it today is `accessibleChildren: ["span"]`, which also makes `<h1><span /></h1>` pass. But that's listed as invalid in `heading-has-content.test.ts`. 

Real-world case: a codebase that replaced `v-html` with a safe-by-default `v-safe-html` wrapper, where the directive normally sits on a child element.

### What this PR changes
One line in `hasAccessibleDirective()`, reusing the existing `hasChildWithDirective()` helper. 
Also applies to `anchor-has-content`, which shares `hasContent()`.
Included a test case for both.

Thank you for the work. And thank you for considering this.